### PR TITLE
fix error when AdvertisingProvider is undefined

### DIFF
--- a/src/components/AdvertisingProvider.js
+++ b/src/components/AdvertisingProvider.js
@@ -50,7 +50,9 @@ export default class AdvertisingProvider extends Component {
     }
 
     componentWillUnmount() {
-        this.teardown();
+        if (this.props.config) {
+            this.teardown();
+        }
     }
 
     async teardown() {

--- a/src/components/AdvertisingProvider.test.js
+++ b/src/components/AdvertisingProvider.test.js
@@ -168,6 +168,12 @@ describe('The AdvertisingProvider component', () => {
             }, 0);
         });
 
+        it('does not tear down the Advertising module if the config is undefined', () => {
+            provider.unmount();
+
+            mockTeardown.should.not.have.been.calledOnce;
+        });
+
         afterEach(resetMocks);
     });
 


### PR DESCRIPTION
When the `AdvertisingProvider` config is `undefined`, the `teardown` function should not execute. 