### PR TITLE
fix: set advertising queue array

### DIFF
--- a/src/Advertising.js
+++ b/src/Advertising.js
@@ -91,7 +91,7 @@ export default class Advertising {
     await Promise.all(teardownQueueItems);
     this.slots = {};
     this.gptSizeMappings = {};
-    this.queue = {};
+    this.queue = [];
   }
 
   activate(id, customEventHandlers = {}) {


### PR DESCRIPTION
Advertising queue is constructed as an array but when unmounting it is set to an object.
This might be causing the error reports mentioned [here](https://github.com/eBayClassifiedsGroup/react-advertising/issues/61#issue-894073269)