### PR TITLE
new interstitial option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
+## 4.0.1 / XX May 2021
+
+- implement interstial ad slot option
+
 ## 4.0.0 / 19 May 2021
 
-- Use of Prebid.js is now optional, you can display ads using only GPT (issue
-  #37, PR #44)
+- Use of Prebid.js is now optional, you can display ads using only GPT (issue #37, PR #44)
 - Ads can now be lazy loaded, through global or individual slot configuration,
   even when using Prebid (issue #25, PR #47)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.1.0
+## 4.1.0 / 22 June 2021
 
 - Added interstitial ad slot option
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.0.1 / XX May 2021
+## 4.0.1 / X June 2021
 
 - implement interstial ad slot option
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
-## 4.0.1 / X June 2021
+## 4.1.0
 
-- implement interstial ad slot option
+- Added interstitial ad slot option
 
 ## 4.0.0 / 19 May 2021
 
-- Use of Prebid.js is now optional, you can display ads using only GPT (issue #37, PR #44)
+- Use of Prebid.js is now optional, you can display ads using only GPT (issue
+  #37, PR #44)
 - Ads can now be lazy loaded, through global or individual slot configuration,
   even when using Prebid (issue #25, PR #47)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ layout!**
   mount to the DOM
 - Works well in single page applications with multiple routes
 - Suitable for server-side-rendering
-- Supports lazy loading, even for Prebid ads, individually configurable per ad slot
+- Supports lazy loading, even for Prebid ads, individually configurable per ad
+  slot
 
 [![Test](https://github.com/eBayClassifiedsGroup/react-advertising/actions/workflows/ci.yml/badge.svg)](https://github.com/eBayClassifiedsGroup/react-advertising/actions/workflows/ci.yml)[![Coverage Status](https://coveralls.io/repos/github/eBayClassifiedsGroup/react-advertising/badge.svg?branch=master)](https://coveralls.io/github/eBayClassifiedsGroup/react-advertising?branch=master)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-advertising",
-  "version": "4.1.0-beta.65.1",
+  "version": "4.1.0-beta.65.2",
   "description": "Library for display ads in React applications",
   "main": "lib/index.js",
   "unpkg": "dist/react-advertising.min.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-advertising",
-  "version": "4.0.0",
+  "version": "4.0.1-interstitial.0",
   "description": "Library for display ads in React applications",
   "main": "lib/index.js",
   "unpkg": "dist/react-advertising.min.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-advertising",
-  "version": "4.1.0-beta.65.0",
+  "version": "4.1.0-beta.65.1",
   "description": "Library for display ads in React applications",
   "main": "lib/index.js",
   "unpkg": "dist/react-advertising.min.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-advertising",
-  "version": "4.1.0-beta.65.2",
+  "version": "4.1.0-beta.65.3",
   "description": "Library for display ads in React applications",
   "main": "lib/index.js",
   "unpkg": "dist/react-advertising.min.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-advertising",
-  "version": "4.0.1-interstitial.0",
+  "version": "4.0.1",
   "description": "Library for display ads in React applications",
   "main": "lib/index.js",
   "unpkg": "dist/react-advertising.min.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-advertising",
-  "version": "4.0.1",
+  "version": "4.1.0-beta.65.0",
   "description": "Library for display ads in React applications",
   "main": "lib/index.js",
   "unpkg": "dist/react-advertising.min.js",

--- a/src/Advertising.js
+++ b/src/Advertising.js
@@ -27,12 +27,7 @@ export default class Advertising {
         ? typeof window.pbjs !== 'undefined'
         : this.config.usePrebid;
     this.executePlugins('setup');
-    const {
-      slots,
-      outOfPageSlots,
-      queue,
-      isPrebidUsed,
-    } = this;
+    const { slots, outOfPageSlots, queue, isPrebidUsed } = this;
     this.setupCustomEvents();
     const setUpQueueItems = [
       Advertising.queueForGPT(this.setupGpt.bind(this), this.onError),

--- a/src/Advertising.js
+++ b/src/Advertising.js
@@ -277,7 +277,7 @@ export default class Advertising {
         window.googletag.enums.OutOfPageFormat.INTERSTITIAL
       );
       if (slot) {
-        const entries = Object.entries(targeting);
+        const entries = Object.entries(targeting || []);
         for (let i = 0; i < entries.length; i++) {
           const [key, value] = entries[i];
           slot.setTargeting(key, value);

--- a/src/Advertising.js
+++ b/src/Advertising.js
@@ -212,6 +212,9 @@ export default class Advertising {
   }
 
   defineSlots() {
+    if (!this.config.slots) {
+      return;
+    }
     this.config.slots.forEach(
       ({
         id,

--- a/src/Advertising.test.js
+++ b/src/Advertising.test.js
@@ -507,8 +507,7 @@ describe('When I instantiate an advertising main module with an interstitial slo
     interstitialSlotConfig.interstitialSlot = {
       path: 'Path/Interstitial',
       targeting: {
-        a: 'int123',
-        ab: 'version2'
+        a: 'int123'
       }
     };
 
@@ -685,6 +684,7 @@ function setupGoogletag() {
   const originalGoogletag = global.googletag;
   global.googletag = {
     cmd: { push: jest.fn((func) => func()) },
+    enums: { OutOfPageFormat: { INTERSTITIAL: 2 } }
   };
   global.googletag.fakeSlots = [];
   global.googletag.defineSlot = jest.fn(() => {
@@ -699,6 +699,7 @@ function setupGoogletag() {
   global.googletag.defineOutOfPageSlot = jest.fn(() => {
     const fakeSlot = {};
     fakeSlot.addService = jest.fn().mockReturnValue(fakeSlot);
+    fakeSlot.setTargeting = jest.fn();
     global.googletag.fakeSlots.push(fakeSlot);
     return fakeSlot;
   });

--- a/src/Advertising.test.js
+++ b/src/Advertising.test.js
@@ -507,8 +507,8 @@ describe('When I instantiate an advertising main module with an interstitial slo
     interstitialSlotConfig.interstitialSlot = {
       path: 'Path/Interstitial',
       targeting: {
-        a: 'int123'
-      }
+        a: 'int123',
+      },
     };
 
     advertising = new Advertising(interstitialSlotConfig);
@@ -539,8 +539,8 @@ describe('When I instantiate an advertising main module with an interstitial slo
     interstitialSlotConfig.interstitialSlot = {
       path: 'Path/Interstitial',
       targeting: {
-        a: 'int123'
-      }
+        a: 'int123',
+      },
     };
 
     advertising = new Advertising(interstitialSlotConfig);
@@ -714,7 +714,7 @@ function setupGoogletag() {
   const originalGoogletag = global.googletag;
   global.googletag = {
     cmd: { push: jest.fn((func) => func()) },
-    enums: { OutOfPageFormat: { INTERSTITIAL: 2 } }
+    enums: { OutOfPageFormat: { INTERSTITIAL: 2 } },
   };
   global.googletag.fakeSlots = [];
   global.googletag.defineSlot = jest.fn(() => {
@@ -727,7 +727,10 @@ function setupGoogletag() {
     return fakeSlot;
   });
   global.googletag.defineOutOfPageSlot = jest.fn((path, id) => {
-    if (global.googletag.interstitialNotProvided && id === window.googletag.enums.OutOfPageFormat.INTERSTITIAL) {
+    if (
+      global.googletag.interstitialNotProvided &&
+      id === window.googletag.enums.OutOfPageFormat.INTERSTITIAL
+    ) {
       return;
     }
     const fakeSlot = {};

--- a/src/Advertising.test.js
+++ b/src/Advertising.test.js
@@ -400,6 +400,7 @@ describe('When I instantiate an advertising main module with plugins', () => {
         teardownGpt: jest.fn(),
         displaySlots: jest.fn(),
         displayOutOfPageSlot: jest.fn(),
+        refreshInterstitialSlot: jest.fn(),
       },
     ];
     advertising = new Advertising(config, plugins);
@@ -426,6 +427,9 @@ describe('When I instantiate an advertising main module with plugins', () => {
     describe("the plugin's hook for displaying outOfPage slots", () =>
       void it('is called', () =>
         expect(plugins[0].displayOutOfPageSlot).toHaveBeenCalled()));
+    describe("the plugin's hook for refreshing interstitial slot", () =>
+      void it('is called', () =>
+        expect(plugins[0].refreshInterstitialSlot).toHaveBeenCalled()));
     describe('and call the teardown method', () => {
       beforeEach(() => {
         jest.clearAllMocks();
@@ -449,6 +453,9 @@ describe('When I instantiate an advertising main module with plugins', () => {
       describe("the plugin's hook for displaying outOfPage slots", () =>
         void it('is not called', () =>
           expect(plugins[0].displayOutOfPageSlot).toHaveBeenCalledTimes(0)));
+      describe("the plugin's hook for refreshing interstiotials slots", () =>
+        void it('is not called', () =>
+          expect(plugins[0].refreshInterstitialSlot).toHaveBeenCalledTimes(0)));
     });
   });
   afterEach(() => {
@@ -482,6 +489,38 @@ describe('When I instantiate an advertising main module with outOfPageSlots', ()
     it('is defined for the “outOfPageSlot2” ad with the correct parameters', () =>
       expect(
         global.googletag.defineOutOfPageSlot.mock.calls[1]
+      ).toMatchSnapshot());
+  });
+  afterEach(() => {
+    global.pbjs = originalPbjs;
+    global.googletag = originalGoogletag;
+  });
+});
+
+describe('When I instantiate an advertising main module with an interstitial slot', () => {
+  let originalPbjs, originalGoogletag, advertising, interstitialSlotConfig;
+  beforeEach(() => {
+    originalPbjs = setupPbjs();
+    originalGoogletag = setupGoogletag();
+
+    interstitialSlotConfig = { ...config };
+    interstitialSlotConfig.interstitialSlot = {
+      path: 'Path/Interstitial',
+      targeting: {
+        a: 'int123',
+        ab: 'version2'
+      }
+    };
+
+    advertising = new Advertising(interstitialSlotConfig);
+  });
+  describe('a GPT interstitial slot', () => {
+    beforeEach(() => advertising.setup());
+    it('is defined from given data', () =>
+      expect(global.googletag.defineOutOfPageSlot).toHaveBeenCalledTimes(1));
+    it('is defined with the correct parameters', () =>
+      expect(
+        global.googletag.defineOutOfPageSlot.mock.calls[0]
       ).toMatchSnapshot());
   });
   afterEach(() => {

--- a/src/Advertising.test.js
+++ b/src/Advertising.test.js
@@ -1,5 +1,5 @@
 import Advertising from './Advertising';
-import { config, DIV_ID_BAR, DIV_ID_FOO } from './utils/testAdvertisingConfig';
+import { config, configWithoutSlots, DIV_ID_BAR, DIV_ID_FOO } from './utils/testAdvertisingConfig';
 
 const GPT_SIZE_MAPPING = [
   [[0, 0], []],
@@ -554,6 +554,22 @@ describe('When I instantiate an advertising main module with an interstitial slo
   });
   afterEach(() => {
     global.pbjs = originalPbjs;
+    global.googletag = originalGoogletag;
+  });
+});
+
+describe('When I instantiate an advertising main module and call the setup method with no slots given', () => {
+  let originalGoogletag, advertising;
+  beforeEach(() => {
+    originalGoogletag = setupGoogletag();
+    advertising = new Advertising(configWithoutSlots);
+    advertising.setup();
+  });
+  describe('a GPT slot', () => {
+    it('is not defined', () =>
+      expect(global.googletag.defineSlot).not.toHaveBeenCalled());
+  });
+  afterEach(() => {
     global.googletag = originalGoogletag;
   });
 });

--- a/src/__snapshots__/Advertising.test.js.snap
+++ b/src/__snapshots__/Advertising.test.js.snap
@@ -262,6 +262,11 @@ Array [
                     },
                   ],
                 },
+                "enums": Object {
+                  "OutOfPageFormat": Object {
+                    "INTERSTITIAL": 2,
+                  },
+                },
                 "fakeSizeMapping": Object {
                   "addSize": [MockFunction] {
                     "calls": Array [
@@ -1092,6 +1097,11 @@ Object {
                 },
               ],
             },
+            "enums": Object {
+              "OutOfPageFormat": Object {
+                "INTERSTITIAL": 2,
+              },
+            },
             "fakeSizeMapping": Object {
               "addSize": [MockFunction] {
                 "calls": Array [
@@ -1703,6 +1713,11 @@ Object {
                 },
               ],
             },
+            "enums": Object {
+              "OutOfPageFormat": Object {
+                "INTERSTITIAL": 2,
+              },
+            },
             "fakeSizeMapping": Object {
               "addSize": [MockFunction] {
                 "calls": Array [
@@ -2115,6 +2130,13 @@ Object {
 }
 `;
 
+exports[`When I instantiate an advertising main module with an interstitial slot a GPT interstitial slot is defined with the correct parameters 1`] = `
+Array [
+  "Path/Interstitial",
+  2,
+]
+`;
+
 exports[`When I instantiate an advertising main module with outOfPageSlots a GPT outOfPage slot is defined for the “outOfPageSlot1” ad with the correct parameters 1`] = `
 Array [
   "global/ad/unit/path",
@@ -2369,6 +2391,11 @@ Array [
                       "value": undefined,
                     },
                   ],
+                },
+                "enums": Object {
+                  "OutOfPageFormat": Object {
+                    "INTERSTITIAL": 2,
+                  },
                 },
                 "fakeSizeMapping": Object {
                   "addSize": [MockFunction] {
@@ -3132,6 +3159,11 @@ Object {
                 },
               ],
             },
+            "enums": Object {
+              "OutOfPageFormat": Object {
+                "INTERSTITIAL": 2,
+              },
+            },
             "fakeSizeMapping": Object {
               "addSize": [MockFunction] {
                 "calls": Array [
@@ -3742,6 +3774,11 @@ Object {
                   "value": undefined,
                 },
               ],
+            },
+            "enums": Object {
+              "OutOfPageFormat": Object {
+                "INTERSTITIAL": 2,
+              },
             },
             "fakeSizeMapping": Object {
               "addSize": [MockFunction] {

--- a/src/components/utils/AdvertisingConfigPropType.js
+++ b/src/components/utils/AdvertisingConfigPropType.js
@@ -98,6 +98,11 @@ export default PropTypes.shape({
       id: PropTypes.string,
     })
   ),
+  interstitialSlot: PropTypes.objectOf(
+    PropTypes.shape({
+      path: PropTypes.string,
+    })
+  ),
   customEvents: PropTypes.objectOf(
     PropTypes.shape({
       eventMessagePrefix: PropTypes.string.isRequired,

--- a/src/components/utils/AdvertisingConfigPropType.js
+++ b/src/components/utils/AdvertisingConfigPropType.js
@@ -98,11 +98,10 @@ export default PropTypes.shape({
       id: PropTypes.string,
     })
   ),
-  interstitialSlot: PropTypes.objectOf(
-    PropTypes.shape({
-      path: PropTypes.string,
-    })
-  ),
+  interstitialSlot: PropTypes.shape({
+    path: PropTypes.string.isRequired,
+    targeting: PropTypes.object,
+  }),
   customEvents: PropTypes.objectOf(
     PropTypes.shape({
       eventMessagePrefix: PropTypes.string.isRequired,

--- a/src/stories/GptInterstitial.stories.js
+++ b/src/stories/GptInterstitial.stories.js
@@ -6,17 +6,23 @@ import { GptDecorator } from './utils';
 
 export const DefaultStory = () => {
   const config = {
+    slots: [
+      {
+        id: "div-slot",
+        path: "/6355419/Travel/Europe",
+        sizes: [[100, 100]]
+      }
+    ],
     interstitialSlot: {
-      path: '/4288/mobile.homepage/Mob_Interstitial',
-      targeting: {
-        a: 'm138',
-        eagt: '1555325533',
-      },
-    },
+      path: "/6355419/Travel/Europe/France/Paris"
+    }
   };
   return (
     <AdvertisingProvider config={config}>
-      <AdvertisingSlot id="banner-ad" />
+      <AdvertisingSlot id="div-slot" />
+      <a id="link" href="https://www.example.com/">
+        TRIGGER INTERSTITIAL
+      </a>
     </AdvertisingProvider>
   );
 };
@@ -36,8 +42,16 @@ export default {
       source: { type: 'code' },
       description: {
         component: `
-In example of them all, we show an interstitial ad, delivered by the Google Ad 
-Manager, through Google Publisher Tag (GPT).
+This example is the simplest implementation of an interstitial ad, delivered by the Google Ad 
+Manager, through Google Publisher Tag (GPT). see more information of the default implementation here:
+https://developers.google.com/publisher-tag/samples/display-web-interstitial-ad
+
+You can prevent specific links from triggering GPT-managed web interstials by adding a 
+data-google-interstitial="false" attribute to the anchor element or any ancestor of the anchor element.
+
+⚠️ **Please note** currently an interstitial is not working standalone, there must be a basic slot available that would be displayed.
+
+⚠️ **Please note** an interstistial can only triggered in separate window, it doesn't work in an iframe....
         `,
       },
       page: () => (

--- a/src/stories/GptInterstitial.stories.js
+++ b/src/stories/GptInterstitial.stories.js
@@ -1,0 +1,52 @@
+import { Title, Description, Primary } from '@storybook/addon-docs/blocks';
+import React from 'react';
+import AdvertisingConfigPropType from '../components/utils/AdvertisingConfigPropType';
+import { AdvertisingProvider, AdvertisingSlot } from '../index';
+import { GptDecorator } from './utils';
+
+export const DefaultStory = () => {
+  const config = {
+    interstitialSlot: {
+      path: '/4288/mobile.homepage/Mob_Interstitial',
+      targeting: {
+        a: 'm138',
+        eagt: '1555325533',
+      },
+    },
+  };
+  return (
+    <AdvertisingProvider config={config}>
+      <AdvertisingSlot id="banner-ad" />
+    </AdvertisingProvider>
+  );
+};
+
+DefaultStory.propTypes = {
+  config: AdvertisingConfigPropType,
+};
+
+DefaultStory.storyName = 'GPT Interstitial';
+
+export default {
+  title: 'GPT Interstitial',
+  decorators: [GptDecorator],
+  parameters: {
+    docs: {
+      // see https://github.com/storybookjs/storybook/issues/12022
+      source: { type: 'code' },
+      description: {
+        component: `
+In example of them all, we show an interstitial ad, delivered by the Google Ad 
+Manager, through Google Publisher Tag (GPT).
+        `,
+      },
+      page: () => (
+        <>
+          <Title />
+          <Description />
+          <Primary />
+        </>
+      ),
+    },
+  },
+};

--- a/src/utils/testAdvertisingConfig.js
+++ b/src/utils/testAdvertisingConfig.js
@@ -17,7 +17,7 @@ const GLOBAL_AD_UNIT_PATH = 'global/ad/unit/path';
 const SLOT_AD_UNIT_PATH = 'slot/ad/unit/path';
 const USD_TO_EUR_RATE = 2;
 
-export const config = {
+export const configWithoutSlots = {
   active: true,
   path: GLOBAL_AD_UNIT_PATH,
   prebid: {
@@ -25,6 +25,47 @@ export const config = {
     priceGranularity: 'medium',
     bidderSequence: 'random',
   },
+  sizeMappings: {
+    mobailAndTablet: [
+      {
+        viewPortSize: [0, 0],
+        sizes: [],
+      },
+      {
+        viewPortSize: [320, 700],
+        sizes: [
+          [300, 250],
+          [320, 50],
+        ],
+      },
+      {
+        viewPortSize: [1050, 200],
+        sizes: [],
+      },
+    ],
+  },
+  metaData: {
+    usdToEurRate: USD_TO_EUR_RATE,
+  },
+
+  targeting: {
+    eagt: [666],
+    'mt-ab': 'test',
+    'mt-ma': ['Poserwagen'],
+    'mt-mo': ['Brummstinko', 'Grand Umweltverpestino'],
+    'mt-thread': [666],
+    'mt-u2': ['00'],
+    'mt-u4': true,
+  },
+  customEvents: {
+    collapse: {
+      eventMessagePrefix: 'CloseAdvContainer:',
+      divIdPrefix: 'div-gpt-ad-',
+    },
+  },
+};
+export const config = {
+  ...configWithoutSlots,
   slots: [
     {
       id: DIV_ID_FOO,
@@ -69,43 +110,5 @@ export const config = {
         },
       ],
     },
-  ],
-  sizeMappings: {
-    mobailAndTablet: [
-      {
-        viewPortSize: [0, 0],
-        sizes: [],
-      },
-      {
-        viewPortSize: [320, 700],
-        sizes: [
-          [300, 250],
-          [320, 50],
-        ],
-      },
-      {
-        viewPortSize: [1050, 200],
-        sizes: [],
-      },
-    ],
-  },
-  metaData: {
-    usdToEurRate: USD_TO_EUR_RATE,
-  },
-
-  targeting: {
-    eagt: [666],
-    'mt-ab': 'test',
-    'mt-ma': ['Poserwagen'],
-    'mt-mo': ['Brummstinko', 'Grand Umweltverpestino'],
-    'mt-thread': [666],
-    'mt-u2': ['00'],
-    'mt-u4': true,
-  },
-  customEvents: {
-    collapse: {
-      eventMessagePrefix: 'CloseAdvContainer:',
-      divIdPrefix: 'div-gpt-ad-',
-    },
-  },
+  ]
 };


### PR DESCRIPTION
Implement the option to use the special OutOfPageSlot interstitial format.

# How to test

Update dependency to beta version:

```
react-advertising@4.1.0-beta.65.1
```

Create an ad with this config:

```javascript
config = {
    slots: [
        {
            id: "div-slot",
            path: "/6355419/Travel/Europe",
            sizes: [[100, 100]]
        }
    ],
    interstitialSlot: {
        path: '/6355419/Travel/Europe/France/Paris'
    }
};
```