### PR TITLE
Remove min from buckets propType

### DIFF
--- a/src/components/utils/AdvertisingConfigPropType.js
+++ b/src/components/utils/AdvertisingConfigPropType.js
@@ -18,7 +18,6 @@ export default PropTypes.shape({
         buckets: PropTypes.arrayOf(
           PropTypes.shape({
             precision: PropTypes.number,
-            min: PropTypes.number.isRequired,
             max: PropTypes.number.isRequired,
             increment: PropTypes.number.isRequired,
           })
@@ -32,7 +31,6 @@ export default PropTypes.shape({
           buckets: PropTypes.arrayOf(
             PropTypes.shape({
               precision: PropTypes.number,
-              min: PropTypes.number.isRequired,
               max: PropTypes.number.isRequired,
               increment: PropTypes.number.isRequired,
             })
@@ -45,7 +43,6 @@ export default PropTypes.shape({
           buckets: PropTypes.arrayOf(
             PropTypes.shape({
               precision: PropTypes.number,
-              min: PropTypes.number.isRequired,
               max: PropTypes.number.isRequired,
               increment: PropTypes.number.isRequired,
             })
@@ -58,7 +55,6 @@ export default PropTypes.shape({
           buckets: PropTypes.arrayOf(
             PropTypes.shape({
               precision: PropTypes.number,
-              min: PropTypes.number.isRequired,
               max: PropTypes.number.isRequired,
               increment: PropTypes.number.isRequired,
             })

--- a/src/components/utils/AdvertisingConfigPropType.test.js
+++ b/src/components/utils/AdvertisingConfigPropType.test.js
@@ -133,12 +133,12 @@ describe('When I check the prop types with a price granularity', () => {
     { priceGranularity: {}, expectToPass: false },
     {
       priceGranularity: {
-        buckets: [{ precision: 1, min: 2, max: 3, increment: 4 }],
+        buckets: [{ precision: 1, max: 3, increment: 4 }],
       },
       expectToPass: true,
     },
     {
-      priceGranularity: { buckets: [{ min: 2, max: 3, increment: 4 }] },
+      priceGranularity: { buckets: [{ max: 3, increment: 4 }] },
       expectToPass: true,
     },
     {
@@ -146,11 +146,11 @@ describe('When I check the prop types with a price granularity', () => {
       expectToPass: false,
     },
     {
-      priceGranularity: { buckets: [{ min: 2, increment: 4 }] },
+      priceGranularity: { buckets: [{ increment: 4 }] },
       expectToPass: false,
     },
     {
-      priceGranularity: { buckets: [{ min: 2, max: 3 }] },
+      priceGranularity: { buckets: [{ max: 3 }] },
       expectToPass: false,
     },
   ];


### PR DESCRIPTION
https://docs.prebid.org/dev-docs/publisher-api-reference/setConfig.html
> Warning: As of Prebid.js 3.0, the ‘min’ parameter is no longer supported in custom granularities.
>
>Also note an important idiosyncracy of the way that price ranges are supported: the interval starts at the min value, and the max of one range defines the min of the next range. So if the second interval defines an implicit min of 0.99 and goes to 5 with an increment of 0.05, Prebid.js will generate the values: 0.99, 1.04, 1.09, etc.
> 
> This implies that ranges should have max values that are really the min value of next range.