### PR TITLE
Fix empty container error

### DIFF
--- a/src/components/AdvertisingSlot.js
+++ b/src/components/AdvertisingSlot.js
@@ -32,9 +32,9 @@ function AdvertisingSlot({
       { rootMargin }
     );
     observerRef.current.observe(containerDivRef.current);
-    return () => {
+    return () =>
+      containerDivRef.current &&
       observerRef.current.unobserve(containerDivRef.current);
-    };
   }, [activate, config]);
 
   useEffect(() => {

--- a/src/components/AdvertisingSlot.js
+++ b/src/components/AdvertisingSlot.js
@@ -32,9 +32,11 @@ function AdvertisingSlot({
       { rootMargin }
     );
     observerRef.current.observe(containerDivRef.current);
-    return () =>
-      containerDivRef.current &&
-      observerRef.current.unobserve(containerDivRef.current);
+    return () => {
+      if (containerDivRef.current) {
+        observerRef.current.unobserve(containerDivRef.current);
+      }
+    };
   }, [activate, config]);
 
   useEffect(() => {


### PR DESCRIPTION
There are certain scenarios when the container might be removed by an AdBlocker or a different edge case which causes the error `Argument 1 ('target') to IntersectionObserver.unobserve must be an instance of Element`.
This proposed change should fix these error cases.