### PR TITLE
Fix another empty container error

### DIFF
--- a/src/components/AdvertisingSlot.js
+++ b/src/components/AdvertisingSlot.js
@@ -32,9 +32,9 @@ function AdvertisingSlot({
       { rootMargin }
     );
     observerRef.current.observe(containerDivRef.current);
-    return () => {
+    return () =>
+      containerDivRef.current &&
       observerRef.current.unobserve(containerDivRef.current);
-    };
   }, [activate, config]);
 
   useEffect(() => {

--- a/src/components/AdvertisingSlot.js
+++ b/src/components/AdvertisingSlot.js
@@ -26,7 +26,9 @@ function AdvertisingSlot({
       ([{ isIntersecting }]) => {
         if (isIntersecting) {
           activate(id, customEventHandlers);
-          observerRef.current.unobserve(containerDivRef.current);
+          if (containerDivRef.current) {
+            observerRef.current.unobserve(containerDivRef.current);
+          }
         }
       },
       { rootMargin }

--- a/src/components/AdvertisingSlot.js
+++ b/src/components/AdvertisingSlot.js
@@ -32,9 +32,11 @@ function AdvertisingSlot({
       { rootMargin }
     );
     observerRef.current.observe(containerDivRef.current);
-    return () =>
-      containerDivRef.current &&
-      observerRef.current.unobserve(containerDivRef.current);
+    return () => {
+      if (containerDivRef.current) {
+        observerRef.current.unobserve(containerDivRef.current);
+      }
+    };
   }, [activate, config]);
 
   useEffect(() => {


### PR DESCRIPTION
As a followup of https://github.com/eBayClassifiedsGroup/react-advertising/pull/73
There is another case where the unobserve can be called with an empty object causing an error:
`Argument 1 ('target') to IntersectionObserver.unobserve must be an instance of Element`