### PR TITLE
Removing restriction for React version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "author": "Patrick Hund <pahund@eclassifiedsgroup.com>",
   "license": "MIT",
   "peerDependencies": {
-    "react": ">=16.3.0 <18.0.0"
+    "react": ">=16.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.13.14",


### PR DESCRIPTION
Removing the `< 18.0.2` as this prevents the use of this module on React projects using the latest version.