### PR TITLE
Fix incorrect usage of hooks after refactor

### DIFF
--- a/src/components/AdvertisingSlot.js
+++ b/src/components/AdvertisingSlot.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useRef, useContext } from 'react';
+import React, { useLayoutEffect, useRef, useContext } from 'react';
 import AdvertisingContext from '../AdvertisingContext';
 import calculateRootMargin from './utils/calculateRootMargin';
 import isLazyLoading from './utils/isLazyLoading';
@@ -17,7 +17,7 @@ function AdvertisingSlot({
   const { activate, config } = useContext(AdvertisingContext);
   const lazyLoadConfig = getLazyLoadConfig(config, id);
   const isLazyLoadEnabled = isLazyLoading(lazyLoadConfig);
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!config || !isLazyLoadEnabled) {
       return () => {};
     }
@@ -41,7 +41,7 @@ function AdvertisingSlot({
     };
   }, [activate, config]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!config || isLazyLoadEnabled) {
       return;
     }


### PR DESCRIPTION
Fixes https://github.com/eBayClassifiedsGroup/react-advertising/issues/85

> Seems like it actually works all the way up until `4.0.0-beta.3` (maybe even `4.0.0-beta.47.0` but it doesn't compile so we can't know), so the change that broke single request must have happened somewhere here: [v4.0.0-beta.3...v4.0.0-beta.47.1](https://github.com/eBayClassifiedsGroup/react-advertising/compare/v4.0.0-beta.3...v4.0.0-beta.47.1)
> 
> The most obvious thing that comes to my mind is the change from class component to functional component for `AdvertisingSlot`. The `useEffect` hook used is not semantically equivalent to `componentDidMount`. Perhaps the asynchronous nature of `useEffect` causes a wrong order in the flow of registering the ad slots before enabling DFP. It might be that `useLayoutEffect` is more appropriate here.
- https://github.com/eBayClassifiedsGroup/react-advertising/issues/85#issuecomment-1242026599