### PR TITLE
fix: some attributes not getting passed down

### DIFF
--- a/src/components/AdvertisingSlot.js
+++ b/src/components/AdvertisingSlot.js
@@ -11,6 +11,7 @@ function AdvertisingSlot({
   className,
   children,
   customEventHandlers,
+  ...restProps
 }) {
   const observerRef = useRef(null);
   const containerDivRef = useRef();
@@ -54,6 +55,7 @@ function AdvertisingSlot({
       className={className}
       children={children}
       ref={containerDivRef}
+      {...restProps}
     />
   );
 }


### PR DESCRIPTION
This proposed PR fixes a minor issue where some html attributes (e.g. `data-testid`) not getting passed down to the parent `div` element in the `AdvertisingSlot` component.