### PR TITLE
Fix failing test after PR #72

### DIFF
--- a/src/components/utils/AdvertisingConfigPropType.test.js
+++ b/src/components/utils/AdvertisingConfigPropType.test.js
@@ -142,10 +142,6 @@ describe('When I check the prop types with a price granularity', () => {
       expectToPass: true,
     },
     {
-      priceGranularity: { buckets: [{ max: 3, increment: 4 }] },
-      expectToPass: false,
-    },
-    {
       priceGranularity: { buckets: [{ increment: 4 }] },
       expectToPass: false,
     },


### PR DESCRIPTION
PR #72 broke a test where
```
priceGranularity: { buckets: [{ max: 3, increment: 4 }] }
```
Was left as `expectToPass: false` while in reality it should have been changed to valid or preferably removed since the value is identical to the use case directly above it.