### PR TITLE
fix: destructure and pass on data-testid

### DIFF
--- a/src/components/AdvertisingSlot.js
+++ b/src/components/AdvertisingSlot.js
@@ -18,6 +18,7 @@ function AdvertisingSlot({
   const { activate, config } = useContext(AdvertisingContext);
   const lazyLoadConfig = getLazyLoadConfig(config, id);
   const isLazyLoadEnabled = isLazyLoading(lazyLoadConfig);
+  const dataTestId = restProps['data-testid'];
   useLayoutEffect(() => {
     if (!config || !isLazyLoadEnabled) {
       return () => {};
@@ -48,6 +49,7 @@ function AdvertisingSlot({
     }
     activate(id, customEventHandlers);
   }, [activate, config]);
+
   return (
     <div
       id={id}
@@ -55,6 +57,7 @@ function AdvertisingSlot({
       className={className}
       children={children}
       ref={containerDivRef}
+      data-testid={dataTestId}
       {...restProps}
     />
   );


### PR DESCRIPTION
Just small change to enable us to pass down a `data-testid` prop to the parent `div` of the `AdvertisingSlot` component.