### PR TITLE
fix: destructure and pass on aria-hidden

### DIFF
--- a/src/components/AdvertisingSlot.js
+++ b/src/components/AdvertisingSlot.js
@@ -19,6 +19,8 @@ function AdvertisingSlot({
   const lazyLoadConfig = getLazyLoadConfig(config, id);
   const isLazyLoadEnabled = isLazyLoading(lazyLoadConfig);
   const dataTestId = restProps['data-testid'];
+  const ariaHidden = restProps['aria-hidden'];
+
   useLayoutEffect(() => {
     if (!config || !isLazyLoadEnabled) {
       return () => {};
@@ -58,6 +60,7 @@ function AdvertisingSlot({
       children={children}
       ref={containerDivRef}
       data-testid={dataTestId}
+      aria-hidden={ariaHidden}
       {...restProps}
     />
   );


### PR DESCRIPTION
Small change that allows us to pass on the aria-hidden attribute to the ad slot `div`