### PR TITLE
fix: pass on aria-hidden and data-testid props

### DIFF
--- a/src/components/AdvertisingSlot.js
+++ b/src/components/AdvertisingSlot.js
@@ -19,6 +19,8 @@ function AdvertisingSlot({
   const lazyLoadConfig = getLazyLoadConfig(config, id);
   const isLazyLoadEnabled = isLazyLoading(lazyLoadConfig);
   const dataTestId = restProps['data-testid'];
+  const ariaHidden = restProps['aria-hidden'];
+
   useLayoutEffect(() => {
     if (!config || !isLazyLoadEnabled) {
       return () => {};
@@ -58,6 +60,7 @@ function AdvertisingSlot({
       children={children}
       ref={containerDivRef}
       data-testid={dataTestId}
+      aria-hidden={ariaHidden}
       {...restProps}
     />
   );

--- a/src/components/AdvertisingSlot.js
+++ b/src/components/AdvertisingSlot.js
@@ -18,6 +18,7 @@ function AdvertisingSlot({
   const { activate, config } = useContext(AdvertisingContext);
   const lazyLoadConfig = getLazyLoadConfig(config, id);
   const isLazyLoadEnabled = isLazyLoading(lazyLoadConfig);
+  const dataTestId = restProps['data-testid'];
   useLayoutEffect(() => {
     if (!config || !isLazyLoadEnabled) {
       return () => {};
@@ -48,6 +49,7 @@ function AdvertisingSlot({
     }
     activate(id, customEventHandlers);
   }, [activate, config]);
+
   return (
     <div
       id={id}
@@ -55,6 +57,7 @@ function AdvertisingSlot({
       className={className}
       children={children}
       ref={containerDivRef}
+      data-testid={dataTestId}
       {...restProps}
     />
   );


### PR DESCRIPTION
So, after my previous PR, React Advertising still wasn't passing down the `data-testid` attribute to the parent `div` inside the `AdvertisingSlot` component. So, I've made a further change so that it now does pass on `data-testid`. I've also made a change so that it passes down the `aria-hidden` attribute. 

And this time, I've properly tested the changes locally using `npm link` 😁