### PR TITLE
fix: ssr console errors for useLayoutEffect

### DIFF
--- a/src/components/AdvertisingSlot.js
+++ b/src/components/AdvertisingSlot.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useLayoutEffect, useRef, useContext } from 'react';
+import React, { useEffect, useRef, useContext } from 'react';
 import AdvertisingContext from '../AdvertisingContext';
 import calculateRootMargin from './utils/calculateRootMargin';
 import isLazyLoading from './utils/isLazyLoading';
@@ -18,7 +18,7 @@ function AdvertisingSlot({
   const { activate, config } = useContext(AdvertisingContext);
   const lazyLoadConfig = getLazyLoadConfig(config, id);
   const isLazyLoadEnabled = isLazyLoading(lazyLoadConfig);
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (!config || !isLazyLoadEnabled) {
       return () => {};
     }
@@ -42,7 +42,7 @@ function AdvertisingSlot({
     };
   }, [activate, config]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (!config || isLazyLoadEnabled) {
       return;
     }


### PR DESCRIPTION
This PR fixes the `useLayoutEffect` console errors when using React Advertising with a framework that uses server-side rendering, eg NextJS.

It appears that we changed from `useEffect` to `useLayoutEffect` to fix an issue (https://github.com/eBayClassifiedsGroup/react-advertising/issues/85) with GPT single request mode, which started when the `AdvertisingSlot` was refactored into a functional component. 

However, the PR (https://github.com/eBayClassifiedsGroup/react-advertising/pull/89) to fix this issue didn't actually fix it! GPT is still making individual requests for each ad slot and not batching them into a single request. 

You can test this in the [codesandbox](https://codesandbox.io/s/gpt-prebid-npm-es6-forked-0k44wy) that was created to demonstrate and test the issue. 

The last version to correctly use GPT single request mode was v4.0.0-beta.3:
![CleanShot 2022-12-21 at 14 18 18](https://user-images.githubusercontent.com/29311273/208985843-1c7f955c-d2d5-436c-91d6-7aca93e38405.png)

The fix was introduced in v4.2.0 and as you can see it still makes multiple GPT requests:
![CleanShot 2022-12-21 at 14 19 18](https://user-images.githubusercontent.com/29311273/208986000-1c311049-5946-4db0-bf7e-af0c798d6b27.png)

