### PR TITLE
chore: add missing gh-token

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -36,6 +36,7 @@ jobs:
       - name: NPM Release
         env:
           HUSKY: 0
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npx semantic-release


### PR DESCRIPTION
## Description

- Previous token did not had enough permissions. Created a personal token to give the ability to semantic release to push a new tag and create a new commit.
