### PR TITLE
fix: race condition with requestManager for tam & prebid bids

### DIFF
--- a/src/Advertising.test.js
+++ b/src/Advertising.test.js
@@ -4,6 +4,7 @@ import {
   configWithoutSlots,
   DIV_ID_BAR,
   DIV_ID_FOO,
+  TWO_SLOT_QUEUE,
 } from './utils/testAdvertisingConfig';
 
 const GPT_SIZE_MAPPING = [
@@ -895,6 +896,41 @@ describe('When I instantiate and initialize an Advertising module, with gpt.js a
 
     global.apstag = originalApstag;
     global.googletag = originalGoogletag;
+  });
+});
+
+describe('When I instantiate an advertising main module, with both APS and Prebid', () => {
+  let originalApstag, originalPbjs, originalGoogletag;
+  beforeEach(() => {
+    originalPbjs = setupPbjs();
+    originalApstag = setupAps();
+    originalGoogletag = setupGoogletag();
+  });
+
+  afterEach(() => {
+    global.apstag = originalApstag;
+    global.pbjs = originalPbjs;
+    global.googletag = originalGoogletag;
+  });
+
+  it('should call googletag.pubads().refresh() once during setup', async () => {
+    const advertising = new Advertising(config);
+    advertising.queue = TWO_SLOT_QUEUE;
+    await advertising.setup();
+    expect(global.googletag.pubads().refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call googletag.pubads().refresh() twice if two slots request new ads simultaneously', async () => {
+    const advertising = new Advertising(config);
+    advertising.queue = TWO_SLOT_QUEUE;
+    await advertising.setup();
+
+    // setup should call global.googletag.pubads().refresh once
+    expect(global.googletag.pubads().refresh).toHaveBeenCalledTimes(1);
+
+    advertising.activate(DIV_ID_FOO);
+    advertising.activate(DIV_ID_BAR);
+    expect(global.googletag.pubads().refresh).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/src/Advertising.test.js
+++ b/src/Advertising.test.js
@@ -920,6 +920,18 @@ describe('When I instantiate an advertising main module, with both APS and Prebi
     expect(global.googletag.pubads().refresh).toHaveBeenCalledTimes(1);
   });
 
+  it('should call googletag.pubads().refresh() once when a slot requests a new ad', async () => {
+    const advertising = new Advertising(config);
+    advertising.queue = TWO_SLOT_QUEUE;
+    await advertising.setup();
+
+    // setup should call global.googletag.pubads().refresh once
+    expect(global.googletag.pubads().refresh).toHaveBeenCalledTimes(1);
+
+    advertising.activate(DIV_ID_FOO);
+    expect(global.googletag.pubads().refresh).toHaveBeenCalledTimes(2);
+  });
+
   it('should call googletag.pubads().refresh() twice if two slots request new ads simultaneously', async () => {
     const advertising = new Advertising(config);
     advertising.queue = TWO_SLOT_QUEUE;

--- a/src/utils/testAdvertisingConfig.js
+++ b/src/utils/testAdvertisingConfig.js
@@ -17,6 +17,17 @@ const GLOBAL_AD_UNIT_PATH = 'global/ad/unit/path';
 const SLOT_AD_UNIT_PATH = 'slot/ad/unit/path';
 const USD_TO_EUR_RATE = 2;
 
+export const TWO_SLOT_QUEUE = [
+  {
+    id: DIV_ID_FOO,
+    customEventHandlers: {},
+  },
+  {
+    id: DIV_ID_BAR,
+    customEventHandlers: {},
+  },
+];
+
 export const configWithoutSlots = {
   active: true,
   path: GLOBAL_AD_UNIT_PATH,


### PR DESCRIPTION
## Description
This fixes an issue when using both Prebid and Amazon TAM (APS) with React Advertising. 

When multiple `AdvertisingSlots` call the `activate` function at the same time to request a new ad, they all use the same `requestManager` object to keep track of whether the Prebid and APS bids have returned. Because the `requestManager` values are used as conditional to control when an ad gets refreshed, this creates a race condition between the different ad units. The first ad unit to get both bids back gets refreshed/rerendered, the others don't.

The fix was to give every new ad request it's own `requestManager` object, instead of sharing a global object. 
