### PR TITLE
refactor: useIsomorphicLayoutEffect to prevent ssr warnings

### DIFF
--- a/src/components/AdvertisingSlot.js
+++ b/src/components/AdvertisingSlot.js
@@ -1,9 +1,10 @@
 import PropTypes from 'prop-types';
-import React, { useLayoutEffect, useRef, useContext } from 'react';
+import React, { useRef, useContext } from 'react';
 import AdvertisingContext from '../AdvertisingContext';
 import calculateRootMargin from './utils/calculateRootMargin';
 import isLazyLoading from './utils/isLazyLoading';
 import getLazyLoadConfig from './utils/getLazyLoadConfig';
+import { useIsomorphicLayoutEffect } from '../hooks/useIsomorphicLayoutEffect';
 
 function AdvertisingSlot({
   id,
@@ -18,7 +19,8 @@ function AdvertisingSlot({
   const { activate, config } = useContext(AdvertisingContext);
   const lazyLoadConfig = getLazyLoadConfig(config, id);
   const isLazyLoadEnabled = isLazyLoading(lazyLoadConfig);
-  useLayoutEffect(() => {
+
+  useIsomorphicLayoutEffect(() => {
     if (!config || !isLazyLoadEnabled) {
       return () => {};
     }
@@ -42,7 +44,7 @@ function AdvertisingSlot({
     };
   }, [activate, config]);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!config || isLazyLoadEnabled) {
       return;
     }

--- a/src/hooks/useIsomorphicLayoutEffect.js
+++ b/src/hooks/useIsomorphicLayoutEffect.js
@@ -1,0 +1,4 @@
+import { useLayoutEffect, useEffect } from 'react';
+
+export const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;


### PR DESCRIPTION
## Description
I've added a `useIsomorphicLayoutEffect` hook to prevent a `useLayoutEffect` warning if the code gets executed server side. If there's no window, it will use `useEffect` otherwise it will use `useLayoutEffect`. This means that we don't have to implement workarounds in our app.


