### PR TITLE
fix: persistent page-level targeting values

### DIFF
--- a/src/Advertising.js
+++ b/src/Advertising.js
@@ -411,6 +411,10 @@ export default class Advertising {
     this.defineOutOfPageSlots();
     this.defineInterstitialSlot();
     const entries = Object.entries(targeting);
+
+    // clear all previous targeting values before updating
+    pubads.clearTargeting();
+    // set or update page-level targeting
     for (let i = 0; i < entries.length; i++) {
       const [key, value] = entries[i];
       pubads.setTargeting(key, value);

--- a/src/Advertising.test.js
+++ b/src/Advertising.test.js
@@ -1009,6 +1009,7 @@ function setupGoogletag() {
     return fakeSlot;
   });
   global.googletag.setTargeting = jest.fn().mockReturnValue(global.googletag);
+  global.googletag.clearTargeting = jest.fn().mockReturnValue(global.googletag);
   global.googletag.addService = jest.fn().mockReturnValue(global.googletag);
   global.googletag.pubads = jest.fn().mockReturnValue(global.googletag);
   global.googletag.fakeSizeMapping = {

--- a/src/__snapshots__/Advertising.test.js.snap
+++ b/src/__snapshots__/Advertising.test.js.snap
@@ -67,6 +67,17 @@ Array [
             Array [
               Object {
                 "addService": [MockFunction],
+                "clearTargeting": [MockFunction] {
+                  "calls": Array [
+                    Array [],
+                  ],
+                  "results": Array [
+                    Object {
+                      "type": "return",
+                      "value": [Circular],
+                    },
+                  ],
+                },
                 "cmd": Object {
                   "push": [MockFunction] {
                     "calls": Array [
@@ -920,6 +931,17 @@ Object {
           Array [
             Object {
               "addService": [MockFunction],
+              "clearTargeting": [MockFunction] {
+                "calls": Array [
+                  Array [],
+                ],
+                "results": Array [
+                  Object {
+                    "type": "return",
+                    "value": [Circular],
+                  },
+                ],
+              },
               "cmd": Object {
                 "push": [MockFunction] {
                   "calls": Array [
@@ -1498,6 +1520,17 @@ Object {
           Array [
             Object {
               "addService": [MockFunction],
+              "clearTargeting": [MockFunction] {
+                "calls": Array [
+                  Array [],
+                ],
+                "results": Array [
+                  Object {
+                    "type": "return",
+                    "value": [Circular],
+                  },
+                ],
+              },
               "cmd": Object {
                 "push": [MockFunction] {
                   "calls": Array [
@@ -2333,6 +2366,17 @@ Array [
             Array [
               Object {
                 "addService": [MockFunction],
+                "clearTargeting": [MockFunction] {
+                  "calls": Array [
+                    Array [],
+                  ],
+                  "results": Array [
+                    Object {
+                      "type": "return",
+                      "value": [Circular],
+                    },
+                  ],
+                },
                 "cmd": Object {
                   "push": [MockFunction] {
                     "calls": Array [
@@ -3254,6 +3298,17 @@ Object {
           Array [
             Object {
               "addService": [MockFunction],
+              "clearTargeting": [MockFunction] {
+                "calls": Array [
+                  Array [],
+                ],
+                "results": Array [
+                  Object {
+                    "type": "return",
+                    "value": [Circular],
+                  },
+                ],
+              },
               "cmd": Object {
                 "push": [MockFunction] {
                   "calls": Array [
@@ -3832,6 +3887,17 @@ Object {
           Array [
             Object {
               "addService": [MockFunction],
+              "clearTargeting": [MockFunction] {
+                "calls": Array [
+                  Array [],
+                ],
+                "results": Array [
+                  Object {
+                    "type": "return",
+                    "value": [Circular],
+                  },
+                ],
+              },
               "cmd": Object {
                 "push": [MockFunction] {
                   "calls": Array [


### PR DESCRIPTION
## Description
This PR fixes an issue where old page-level targeting values are not getting removed from `googletag.pubads()` when the ad config that gets passed into `AdvertisingProvider` updates. What this mean is that when targeting values are removed from your ad config, they still persist in `googletag.pubads()`.

The fix is to call `pubads.clearTargeting()` to clear all previous targeting values before calling `pubads.setTargeting(key, value)` to pass in the updated targeting values.