### PR TITLE
fix: correctly get aps config for queued ad ids

### DIFF
--- a/src/Advertising.js
+++ b/src/Advertising.js
@@ -96,7 +96,7 @@ export default class Advertising {
       try {
         window.apstag.fetchBids(
           {
-            slots: selectedSlots.map((slot) => slot.aps),
+            slots: queue.map(({ id }) => slots[id].aps),
           },
           () => {
             Advertising.queueForGPT(() => {


### PR DESCRIPTION
## Description

This PR fixes a bug where, for queued ad IDs in a scenario using APS, the APS config was attempted to be read at `slots[id].gpt.aps` instead of `slots[id].aps`, where it actually exists.

The impact is that Amazon TAM is not working for these queued ads. This is currently affecting our website, so a review and merge would be greatly appreciated :)
