### PR TITLE
fix: teardown happening during initial setup

### DIFF
--- a/src/components/AdvertisingProvider.js
+++ b/src/components/AdvertisingProvider.js
@@ -13,6 +13,7 @@ export default class AdvertisingProvider extends Component {
     this.state = {
       activate: this.advertising.activate.bind(this.advertising),
       config: this.props.config,
+      isInitialSetupComplete: false,
     };
   }
 
@@ -66,7 +67,11 @@ export default class AdvertisingProvider extends Component {
   }
 
   async componentWillUnmount() {
-    if (this.props.config) {
+    /**
+     * Prevent the teardown call while initial setup still in progress
+     * otherwise it can create a race condition that breaks the setup process
+     */
+    if (this.props.config && this.state.isInitialSetupComplete) {
       await this.teardown();
     }
   }


### PR DESCRIPTION
## Description
This fixes an issue that can occur if the AdvertisingProvider unmounts during the initial GPT setup. 

I've added a new state value (isInitialSetupComplete), which gets set when the setup completes and prevents `omponentWillUnmount` from calling the teardown function. This ensures we don't create a race condition between the setup and teardown, which can break the display ads.

