### PR TITLE
fix: missing setState for isInitialSetupComplete

### DIFF
--- a/src/components/AdvertisingProvider.js
+++ b/src/components/AdvertisingProvider.js
@@ -20,6 +20,8 @@ export default class AdvertisingProvider extends Component {
   async componentDidMount() {
     if (this.advertising.isConfigReady() && this.props.active) {
       await this.advertising.setup();
+      // eslint-disable-next-line react/no-did-mount-set-state
+      this.setState({ isInitialSetupComplete: true });
     }
   }
 


### PR DESCRIPTION
## Description
- Follow-up from PR #134
- Adds in the missing setState for updating isInitialSetupComplete. I must of deleted it by accident when I was removing all my console logs 😞

