### PR TITLE
fix: remove defaultprops

### DIFF
--- a/src/components/AdvertisingProvider.js
+++ b/src/components/AdvertisingProvider.js
@@ -10,15 +10,19 @@ export default class AdvertisingProvider extends Component {
     super(props);
     this.initialize();
 
+    const { config, active = true } = props;
+
     this.state = {
       activate: this.advertising.activate.bind(this.advertising),
-      config: this.props.config,
+      config,
       isInitialSetupComplete: false,
     };
+
+    this.active = active;
   }
 
   async componentDidMount() {
-    if (this.advertising.isConfigReady() && this.props.active) {
+    if (this.advertising.isConfigReady() && this.active) {
       await this.advertising.setup();
       // eslint-disable-next-line react/no-did-mount-set-state
       this.setState({ isInitialSetupComplete: true });
@@ -31,7 +35,7 @@ export default class AdvertisingProvider extends Component {
       return;
     }
 
-    const { config, active } = this.props;
+    const { config, active = true } = this.props;
     const isConfigReady = this.advertising.isConfigReady();
 
     // activate advertising when the config changes from `undefined`
@@ -112,8 +116,4 @@ AdvertisingProvider.propTypes = {
       teardownGpt: PropTypes.func,
     })
   ),
-};
-
-AdvertisingProvider.defaultProps = {
-  active: true,
 };

--- a/src/components/AdvertisingSlot.js
+++ b/src/components/AdvertisingSlot.js
@@ -11,7 +11,7 @@ function AdvertisingSlot({
   style,
   className,
   children,
-  customEventHandlers,
+  customEventHandlers = {},
   ...restProps
 }) {
   const observerRef = useRef(null);
@@ -68,10 +68,6 @@ AdvertisingSlot.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
   customEventHandlers: PropTypes.objectOf(PropTypes.func).isRequired,
-};
-
-AdvertisingSlot.defaultProps = {
-  customEventHandlers: {},
 };
 
 export default AdvertisingSlot;


### PR DESCRIPTION
Since defaultprops is going to be deprecated, these changes eliminate its use and use the javascript default params.

`Warning: AdvertisingSlot: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.`

