### PR TITLE
fix: mark customEventHandlers as optional

### DIFF
--- a/src/components/AdvertisingSlot.js
+++ b/src/components/AdvertisingSlot.js
@@ -67,7 +67,7 @@ AdvertisingSlot.propTypes = {
   style: PropTypes.object,
   className: PropTypes.string,
   children: PropTypes.node,
-  customEventHandlers: PropTypes.objectOf(PropTypes.func).isRequired,
+  customEventHandlers: PropTypes.objectOf(PropTypes.func),
 };
 
 export default AdvertisingSlot;


### PR DESCRIPTION
## Description

Sorry, my PR above generates a new error as we define a default value for customEventHandlers but at the same time it is marked as required.

Since it has a default value it does not need to be required.

So the error is easily fixed

Related error:

```
Warning: Failed prop type: The prop `customEventHandlers` is marked as required in `AdvertisingSlot`, but its value is `undefined`.
    at AdvertisingSlot (/node_modules/react-advertising/lib/components/AdvertisingSlot.js:37:17)
```
