### PR TITLE
fix: aps integration with regards to size mismatch

### DIFF
--- a/src/Advertising.js
+++ b/src/Advertising.js
@@ -21,7 +21,6 @@ export default class Advertising {
     this.customEventCallbacks = {};
     this.customEventHandlers = {};
     this.queue = [];
-    this.activatedSlots = [];
     this.apsSlotType = 'aps';
     this.setDefaultConfig();
   }
@@ -140,7 +139,6 @@ export default class Advertising {
 
   activate(id, customEventHandlers = {}) {
     const { slots, isPrebidUsed } = this;
-    this.activatedSlots.push(id);
     // check if have slots from configurations
     if (Object.values(slots).length === 0) {
       this.queue.push({ id, customEventHandlers });
@@ -372,9 +370,7 @@ export default class Advertising {
   displaySlots() {
     this.executePlugins('displaySlots');
     this.config.slots.forEach(({ id }) => {
-      if (this.activatedSlots.includes(id)) {
-        window.googletag.display(id);
-      }
+      window.googletag.display(id);
     });
   }
 

--- a/src/Advertising.js
+++ b/src/Advertising.js
@@ -97,16 +97,16 @@ export default class Advertising {
     if (this.isAPSUsed) {
       try {
         window.apstag.fetchBids(
-            {
-              slots: queue.map(({ id }) => slots[id][this.apsSlotType]),
-            },
-            () => {
-              Advertising.queueForGPT(() => {
-                window.apstag.setDisplayBids();
-                requestManager.aps = true; // signals that APS request has completed
-                this.refreshSlots(selectedSlots, requestManager); // checks whether both APS and Prebid have returned
-              }, this.onError);
-            }
+          {
+            slots: queue.map(({ id }) => slots[id][this.apsSlotType]),
+          },
+          () => {
+            Advertising.queueForGPT(() => {
+              window.apstag.setDisplayBids();
+              requestManager.aps = true; // signals that APS request has completed
+              this.refreshSlots(selectedSlots, requestManager); // checks whether both APS and Prebid have returned
+            }, this.onError);
+          }
         );
       } catch (error) {
         this.onError(error);
@@ -172,16 +172,16 @@ export default class Advertising {
     if (this.isAPSUsed) {
       try {
         window.apstag.fetchBids(
-            {
-              slots: [slots[id][this.apsSlotType]],
-            },
-            () => {
-              Advertising.queueForGPT(() => {
-                window.apstag.setDisplayBids();
-                requestManager.aps = true; // signals that APS request has completed
-                this.refreshSlots([slots[id][apsSlotType]], requestManager); // checks whether both APS and Prebid have returned
-              }, this.onError);
-            }
+          {
+            slots: [slots[id][this.apsSlotType]],
+          },
+          () => {
+            Advertising.queueForGPT(() => {
+              window.apstag.setDisplayBids();
+              requestManager.aps = true; // signals that APS request has completed
+              this.refreshSlots([slots[id][apsSlotType]], requestManager); // checks whether both APS and Prebid have returned
+            }, this.onError);
+          }
         );
       } catch (error) {
         this.onError(error);

--- a/src/Advertising.js
+++ b/src/Advertising.js
@@ -179,7 +179,7 @@ export default class Advertising {
             Advertising.queueForGPT(() => {
               window.apstag.setDisplayBids();
               requestManager.aps = true; // signals that APS request has completed
-              this.refreshSlots([slots[id][apsSlotType]], requestManager); // checks whether both APS and Prebid have returned
+              this.refreshSlots([slots[id][this.apsSlotType]], requestManager); // checks whether both APS and Prebid have returned
             }, this.onError);
           }
         );

--- a/src/components/utils/AdvertisingConfigPropType.js
+++ b/src/components/utils/AdvertisingConfigPropType.js
@@ -80,6 +80,7 @@ export default PropTypes.shape({
     pubID: PropTypes.string,
     bidTimeout: PropTypes.number,
     deals: PropTypes.bool,
+    simplerGPT: PropTypes.bool,
   }),
   sizeMappings: PropTypes.objectOf(
     PropTypes.arrayOf(


### PR DESCRIPTION
## Description

The current APS integration does not work correctly if using the GAM size mapping feature. This is because while GAM accepts the size mapping feature, and will request the designated sizes at the designated breakpoints, the current APS integration simply uses the size array of the unit, which includes _all_ potential sizes of the unit.

You can see this where the apsSlot is defined in the defineSlots() function. 

This can result in a request for a size that the unit is not currently set up to display. For example a leaderboard unit may be a 320x100 on mobile, a 728x90 on tablet, and a 970x250 on desktop. All of the sizes exist in the "size" array of the unit. That unit may also contain a GAM size mapping definition that states that the 320x100 can only be requested on mobile, 728x90 on tablet, and a 970x250 on desktop. 

The APS call, however, will simply include all 3 of those sizes for every request. This can cause breakage on the site as the creative delivered will likely be larger than the size of the ad unit / placeholder. This will also hurt viewability metrics  (a 728x90 on mobile won't be fully viewable, etc).

Amazon has a newer method of integration called "simplerGPT" which does utilize GAM size mapping definitions. In fact you do not need to define any slot for APS, it will just use the GPT definition. 

You can read about this method [here](https://ams.amazon.com/webpublisher/uam/docs/reference/googletag-sizemapping.html). 

I added a simple check for the presence of "simplerGPT" in the config that if present, will utilize the gpt slot definition for the APS calls, instead of the APS unit that is defined. I've defaulted to the older method to avoid any breakage. 

Testing this I'm able to verify that APS is being called for the correct sizes at the configured breakpoints, versus the older method which requests all listed sizes. 
